### PR TITLE
 ref: Upgraded audio recorder type and mime type format

### DIFF
--- a/SpeakGoodChinese3.xml
+++ b/SpeakGoodChinese3.xml
@@ -704,10 +704,10 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 	    record.style.color = "red";
 		
 		var recordRTC = RecordRTC(mediaStream, {
-			recorderType: StereoAudioRecorder // optionally force WebAudio API to record audio
-			
-		}); 
-		recordRTC.mimeType = {audio: 'audio/wav'};
+			recorderType: MediaStreamRecorder,
+			type: "audio",
+			mimeType: "audio/webm"
+		});
 		
 		clearRecordedData = function () {
 			play.disabled = true;

--- a/audioProcessing.js
+++ b/audioProcessing.js
@@ -219,6 +219,8 @@ function cut_silent_margins (typedArray, sampleRate) {
 	while (firstNonZero < typedArray.length && (isNaN(typedArray[firstNonZero]) || typedArray[firstNonZero] == 0)) {
 		++firstNonZero
 	};
+	// Guard: if the entire buffer is zeros/NaN, do not skip anything
+	if (firstNonZero >= typedArray.length) firstNonZero = 0;
 	
 	// Calculation intensity
 	var currentIntensity = calculate_Intensity (typedArray, sampleRate, 75, 600, 0.01);


### PR DESCRIPTION
- Switched recorderType from StereoAudioRecorder to MediaStreamRecorder
- Updated mimeType to "audio/webm" for compatibility with newer browser support and better file size optimization. Switch from StereoAudioRecorder to recordRTC/webm to allow recording.

"Works for me"
(NixOS, Edge Browser) - on localhost with caddy as the webserver.

Thanks a lot for the project, looks like this would be very useful for practicing those tones !